### PR TITLE
优化登陆页面的开放重定向问题

### DIFF
--- a/install/docker/project.py
+++ b/install/docker/project.py
@@ -163,7 +163,7 @@ class Myauthdbview(AuthDBView):
                         # 仅开放同域名跳转，避免开放式URL重定向漏洞
                         from werkzeug.urls import url_parse
                         parsed_url = url_parse(comed_url)
-                        if not parsed_url.netloc or parsed_url.netloc == request.host:
+                        if (not parsed_url.netloc and parsed_url.path) or parsed_url.netloc == request.host:
                             return redirect(comed_url)
                     return redirect(self.appbuilder.get_url_for_index)
         # 如果已经登录了，那么直接进去首页

--- a/install/kubernetes/cube/overlays/config/project.py
+++ b/install/kubernetes/cube/overlays/config/project.py
@@ -163,7 +163,7 @@ class Myauthdbview(AuthDBView):
                         # 仅开放同域名跳转，避免开放式URL重定向漏洞
                         from werkzeug.urls import url_parse
                         parsed_url = url_parse(comed_url)
-                        if not parsed_url.netloc or parsed_url.netloc == request.host:
+                        if (not parsed_url.netloc and parsed_url.path) or parsed_url.netloc == request.host:
                             return redirect(comed_url)
                     return redirect(self.appbuilder.get_url_for_index)
         # 如果已经登录了，那么直接进去首页

--- a/myapp/project.py
+++ b/myapp/project.py
@@ -163,7 +163,7 @@ class Myauthdbview(AuthDBView):
                         # 仅开放同域名跳转，避免开放式URL重定向漏洞
                         from werkzeug.urls import url_parse
                         parsed_url = url_parse(comed_url)
-                        if not parsed_url.netloc or parsed_url.netloc == request.host:
+                        if (not parsed_url.netloc and parsed_url.path) or parsed_url.netloc == request.host:
                             return redirect(comed_url)
                     return redirect(self.appbuilder.get_url_for_index)
 


### PR DESCRIPTION
增加默认登陆方式中login_url的域名校验demo，实现默认登陆仅允许同域名跳转，避免开放重定向风险。

`redirect(request.referer)`操作也存在开放重定向风险，但考虑到可通过配置istio解决，不对代码作改动。