### PR TITLE
worker数量自适应与gevent模块猴子补丁

### DIFF
--- a/myapp/__init__.py
+++ b/myapp/__init__.py
@@ -1,3 +1,7 @@
+# 关键：替换标准库的阻塞调用为非阻塞版本, 必须在所有其他导入前执行，确保覆盖标准库
+from gevent import monkey
+monkey.patch_all()
+
 import datetime
 import time, random
 from copy import deepcopy


### PR DESCRIPTION
1. 通过k8s部署，生产环境通过gunicorn方式启动，根据deploy资源的resource.limits.cpu字段自适配cpu资源限制，最佳worker数量为分配的IO密集项目cpu核心数*2+1
2. 容器内部的日志输出到终端
3. 同步代码（依赖标准库的I/O操作，如 socket、time.sleep 等）默认是阻塞的，需要通过gevent的猴子补丁（monkey patching）将其替换为非阻塞版本，否则gevent无法在I/O时切换协程，性能会大打折扣